### PR TITLE
Fix this/self mixup

### DIFF
--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -76,7 +76,7 @@ NodeRedisPubsub.prototype.on = NodeRedisPubsub.prototype.subscribe = function(ch
 
   var removeListener = function(callback){
     self.receiver.removeListener('pmessage', pmessageHandler);
-		return this.receiver.punsubscribe(this.prefix + channel, callback);
+    return self.receiver.punsubscribe(self.prefix + channel, callback);
   };
 
   return removeListener;


### PR DESCRIPTION
removeListener was referring to `this` which is no longer the correct context when called by the application.